### PR TITLE
Allow using ssh-agent in libvirt connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ These can be declared as input vars inside a `.tfvars` file too
 export TF_VAR_SSH_HOST="XXX.XXX.XXX.XXX"
 export TF_VAR_SSH_USERNAME="yourUsername"
 export TF_VAR_SSH_PASSWORD="yourPassword"
-export TF_VAR_SSH_PRIVATE_KEY_PATH="~/.ssh/id_ed25519"
+export TF_VAR_SSH_KEY_PATH="~/.ssh/id_ed25519"
  ```
 
 ### 2. Install some REQUIRED dependencies in local machine
@@ -87,9 +87,9 @@ locals {
       host     = var.SSH_HOST
       username = var.SSH_USERNAME
 
-      password         = var.SSH_PASSWORD
-      private_key_path = var.SSH_PRIVATE_KEY_PATH
-      mode             = "password"
+      password = var.SSH_PASSWORD
+      key_path = var.SSH_KEY_PATH
+      mode     = "password"
     }
 
     # Parameters related to those files used/thrown at some point on VM creation

--- a/examples/bootstrap-kubernetes-vms/data.tf
+++ b/examples/bootstrap-kubernetes-vms/data.tf
@@ -5,12 +5,12 @@ locals {
 
     # Configuration for SSH connection parameters
     ssh_connection = {
-      host             = var.SSH_HOST
-      username         = var.SSH_USERNAME
+      host     = var.SSH_HOST
+      username = var.SSH_USERNAME
 
-      password         = var.SSH_PASSWORD
-      private_key_path = var.SSH_PRIVATE_KEY_PATH
-      mode             = "password"
+      password = var.SSH_PASSWORD
+      key_path = var.SSH_KEY_PATH
+      mode     = "password"
     }
 
     # Parameters related to those files used/thrown at some point on VM creation
@@ -64,7 +64,7 @@ locals {
       # Using 'OrangePi 5' as hypervisor. This SBC is quite new, so there is no specific machine type for it
       # Use generic 'virt' to apply all needed patches for this kind of environments
       # Ref: https://www.qemu.org/docs/master/system/target-arm.html
-      arch = "aarch64"
+      arch    = "aarch64"
       machine = "virt"
 
       vcpu   = 2
@@ -84,7 +84,7 @@ locals {
       # Using 'OrangePi 5' as hypervisor. This SBC is quite new, so there is no specific machine type for it
       # Use generic 'virt' to apply all needed patches for this kind of environments
       # Ref: https://www.qemu.org/docs/master/system/target-arm.html
-      arch = "aarch64"
+      arch    = "aarch64"
       machine = "virt"
 
       vcpu   = 2

--- a/examples/bootstrap-kubernetes-vms/variables.tf
+++ b/examples/bootstrap-kubernetes-vms/variables.tf
@@ -2,7 +2,7 @@
 variable "SSH_HOST" {
   type        = string
   description = "The IP of the SSH host to connect to"
-  default = "192.168.2.138"
+  default     = "192.168.2.138"
 }
 
 # Username to be authenticated in the host
@@ -10,7 +10,7 @@ variable "SSH_HOST" {
 variable "SSH_USERNAME" {
   type        = string
   description = "The username to be authenticated in the SSH host"
-  default = "root"
+  default     = "root"
 }
 
 # Password to be authenticated in the host
@@ -18,13 +18,12 @@ variable "SSH_USERNAME" {
 variable "SSH_PASSWORD" {
   type        = string
   description = "The password to be authenticated in the SSH host"
-  default = "placeholder"
+  default     = "placeholder"
 }
 
-
-# Path to the private key to be uploaded to the host
+# Path to the ssh key (public or private) to be uploaded to the host
 # This key will be used for API calls
-variable "SSH_PRIVATE_KEY_PATH" {
-  description = "The path to the private key that will be authorized in the SSH host"
+variable "SSH_KEY_PATH" {
+  description = "The path to the ssh key that will be authorized in the SSH host"
   type        = string
 }

--- a/terraform/templates/data.auto.tfvars.example
+++ b/terraform/templates/data.auto.tfvars.example
@@ -3,12 +3,12 @@ globals = {
 
     # Configuration for SSH connection parameters
     ssh_connection = {
-      host             = var.SSH_HOST
-      username         = var.SSH_USERNAME
+      host     = var.SSH_HOST
+      username = var.SSH_USERNAME
 
-      password         = var.SSH_PASSWORD
-      private_key_path = var.SSH_PRIVATE_KEY_PATH
-      mode             = "password"
+      password = var.SSH_PASSWORD
+      key_path = var.SSH_KEY_PATH
+      mode     = "password"
     }
 
     # Parameters related to those files used/thrown at some point on VM creation

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -16,8 +16,8 @@ terraform {
 provider "libvirt" {
   # Use password when mode is set to 'password'. Use SSH key in other cases
   uri = var.globals.ssh_connection.mode == "password" ? (
-   "qemu+ssh://${var.globals.ssh_connection.username}:${var.globals.ssh_connection.password}@${var.globals.ssh_connection.host}/system?sshauth=ssh-password&no_verify=1"
-  ) : (
-   "qemu+ssh://${var.globals.ssh_connection.username}@${var.globals.ssh_connection.host}/system?keyfile=${var.globals.ssh_connection.private_key_path}&sshauth=privkey&no_verify=1"
+    "qemu+ssh://${var.globals.ssh_connection.username}:${var.globals.ssh_connection.password}@${var.globals.ssh_connection.host}/system?sshauth=ssh-password&no_verify=1"
+    ) : (
+    "qemu+ssh://${var.globals.ssh_connection.username}@${var.globals.ssh_connection.host}/system?keyfile=${var.globals.ssh_connection.key_path}&sshauth=privkey,agent&no_verify=1"
   )
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,9 +15,9 @@ variable "globals" {
       # Password to be authenticated in the host
       password = optional(string)
 
-      # Path to the private key to be authenticated in the host
+      # Path to the ssh key (public or private) to be authenticated in the host
       # This key should already exists on the host machine
-      private_key_path = optional(string)
+      key_path = optional(string)
 
       # Which auth method use on SSH connection: password, key
       mode = string


### PR DESCRIPTION
If we use ssh-agent, instead of have the private key in plain on the disk, I get the following error:

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: failed to dial libvirt: could not configure SSH authentication methods
│ 
│   with module.arm-virtual-machines.provider["registry.terraform.io/dmacvicar/libvirt"],
│   on ../../../../metal-cloud/terraform/terraform.tf line 16, in provider "libvirt":
│   16: provider "libvirt" {
```

To solve this we need to allow to `libvirt` to authenticate the ssh connection using an `agent` too.